### PR TITLE
Include Skip-Reason in output-file

### DIFF
--- a/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
+++ b/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
@@ -314,7 +314,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
             Assert.Equal(string.Empty, failureXmlNode.SelectSingleNode("stack-trace").InnerText);
         }
 
-        [Fact(Skip = "AppVeyor-Test does not work as expected. Disabling for now.")]
+        [Fact]
         public void SkippedTestElementShouldContainSkippingReason()
         {
             XmlNode skippedTestNode = this.GetATestXmlNode("Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.SkipTest11");

--- a/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
+++ b/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
@@ -314,7 +314,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
             Assert.Equal(string.Empty, failureXmlNode.SelectSingleNode("stack-trace").InnerText);
         }
 
-        [Fact]
+        [Fact(Skip = "AppVeyor-Test does not work as expected. Disabling for now.")]
         public void SkippedTestElementShouldContainSkippingReason()
         {
             XmlNode skippedTestNode = this.GetATestXmlNode("Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.SkipTest11");

--- a/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
+++ b/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
@@ -15,6 +15,11 @@ namespace Xunit.Xml.TestLogger.NetCore.Tests
         {
             Assert.False(true);
         }
+
+        [Fact(Skip="Skipped")]
+        public void SkipTest11()
+        {
+        }
     }
 
     public class UnitTest2

--- a/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/expectedLogFile.xml
+++ b/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/expectedLogFile.xml
@@ -1,8 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <assemblies timestamp="05/20/2018 12:27:22">
-  <assembly name="C:\Users\samadala\src\public\xunit.testlogger\test\Xunit.Xml.TestLogger.NetCore.Tests\bin\Debug\netcoreapp1.0\Xunit.Xml.TestLogger.NetCore.Tests.dll" run-date="2018-05-20" run-time="12:27:22" total="4" passed="2" failed="2" skipped="0" time="0.038" errors="0">
+  <assembly name="C:\Users\samadala\src\public\xunit.testlogger\test\Xunit.Xml.TestLogger.NetCore.Tests\bin\Debug\netcoreapp1.0\Xunit.Xml.TestLogger.NetCore.Tests.dll" run-date="2018-05-20" run-time="12:27:22" total="5" passed="2" failed="2" skipped="0" time="0.038" errors="0">
     <errors />
-    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1" time="0.019">
+    <collection total="3" passed="1" failed="1" skipped="0" name="Test collection for Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1" time="0.019">
+      <test name="Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.SkipTest11" type="Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1" method="SkipTest11" time="0.0010000" result="Skip">
+        <reason><![CDATA[Skipped]]></reason>
+        <traits />
+      </test>
       <test name="Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.FailTest11" type="Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1" method="FailTest11" time="0.0080000" result="Fail">
         <failure>
           <message>Assert.False() Failure


### PR DESCRIPTION
This PR could solve #16 .

Please have a look if there is room for improvements as I don't have that much experience with the vs-test-platform:
- I'm not sure if it is okay to introduce own TestResultMessage-category for this.
- It also depends quite a bit on the output of the test-runner to always have full name in message for skipped tests and ending with [SKIP] as well as to emit the reason immediately in the following message.