### PR TITLE
fix: escape name for control chars in generated xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased (v3.0.x)
 
-* Refactor to support [core testlogger][]
-* Compatibility: minimum framework is netstandard1.5 and TestPlatform 15.5.0
-* Use test run start and end times for run duration reporting for assembly. See #26
+- Refactor to support [core testlogger][]
+- Compatibility: minimum framework is netstandard1.5 and TestPlatform 15.5.0
+- Use test run start and end times for run duration reporting for assembly. See #26
+- Escape control characters from the generated xml. See #25
+- Token expansion for `{assembly}` and `{framework}` in results file. See
+  https://github.com/spekt/testlogger/wiki/Logger-Configuration
 
 [core testlogger]: https://github.com/spekt/testlogger

--- a/README.md
+++ b/README.md
@@ -34,5 +34,9 @@ A path for the report file can be specified as follows:
 
 **Note:** the arguments to `--logger` should be in quotes since `;` is treated as a command delimiter in shell.
 
+All common options to the logger is documented [in the wiki][config-wiki].
+
+[config-wiki]: https://github.com/spekt/testlogger/wiki/Logger-Configuration
+
 ## License
 MIT

--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -4,7 +4,7 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NETTestSdkVersion>15.7.2</NETTestSdkVersion>
     <MoqVersion>4.9.0</MoqVersion>
-    <TestLoggerVersion>3.0.26</TestLoggerVersion>
+    <TestLoggerVersion>3.0.28</TestLoggerVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.5.0</NETTestSdkMinimumVersion>

--- a/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
+++ b/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
@@ -4,6 +4,7 @@
 namespace Xunit.Xml.TestLogger.AcceptanceTests
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Linq;
@@ -133,7 +134,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         {
             XmlNode assemblyNode = this.testResultsXmlDocument.SelectSingleNode(TestResultsXmlTests.AssemblyElement);
 
-            Assert.Equal("5", assemblyNode.Attributes["total"].Value);
+            Assert.Equal("6", assemblyNode.Attributes["total"].Value);
         }
 
         [Fact]
@@ -141,7 +142,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         {
             XmlNode assemblyNode = this.testResultsXmlDocument.SelectSingleNode(TestResultsXmlTests.AssemblyElement);
 
-            Assert.Equal("2", assemblyNode.Attributes["passed"].Value);
+            Assert.Equal("3", assemblyNode.Attributes["passed"].Value);
         }
 
         [Fact]
@@ -192,7 +193,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         {
             XmlNodeList collectionElementNodeList = this.testResultsXmlDocument.SelectNodes(TestResultsXmlTests.CollectionElement);
 
-            Assert.True(collectionElementNodeList.Count == 2);
+            Assert.Equal(3, collectionElementNodeList.Count);
         }
 
         [Fact]
@@ -237,11 +238,23 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         }
 
         [Fact]
-        public void CollectionElementShouldContainThreeTestsElemets()
+        public void CollectionElementShouldContainThreeTestsElements()
         {
             XmlNode unitTest1Collection = this.GetUnitTest1Collection();
 
             Assert.True(unitTest1Collection.SelectNodes("test").Count == 3);
+        }
+
+        [Fact]
+        public void TestElementNameAttributeShouldBeEscaped()
+        {
+            var testNodes = this.GetTestXmlNodePartial(
+                "UnitTest3",
+                @"Xunit.Xml.TestLogger.NetCore.Tests.UnitTest3.TestInvalidName");
+
+            Assert.Equal(
+                "Xunit.Xml.TestLogger.NetCore.Tests.UnitTest3.TestInvalidName(input: \"Head\\u0080r\")",
+                testNodes.Item(0).Attributes["name"].Value);
         }
 
         [Fact]
@@ -290,7 +303,9 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         [Fact]
         public void PassedTestElementResultAttributeShouldHaveValuePass()
         {
-            XmlNode passedTestXmlNode = this.GetATestXmlNode("Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.PassTest11");
+            XmlNode passedTestXmlNode = this.GetATestXmlNode(
+                "UnitTest1",
+                "Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.PassTest11");
 
             Assert.Equal("Pass", passedTestXmlNode.Attributes["result"].Value);
         }
@@ -317,7 +332,9 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         [Fact]
         public void SkippedTestElementShouldContainSkippingReason()
         {
-            XmlNode skippedTestNode = this.GetATestXmlNode("Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.SkipTest11");
+            XmlNode skippedTestNode = this.GetATestXmlNode(
+                "UnitTest1",
+                "Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.SkipTest11");
             var reasonNodes = skippedTestNode.SelectNodes("reason");
 
             Assert.Equal(1, reasonNodes.Count);
@@ -331,27 +348,38 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
             Assert.Equal(expectedReason, reasonData.Value);
         }
 
-        private XmlNode GetATestXmlNode(string queryTestName = "Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.FailTest11")
+        private XmlNode GetATestXmlNode(
+            string collectionName = "UnitTest1",
+            string queryTestName = "Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1.FailTest11")
         {
-            XmlNode unitTest1Collection = this.GetUnitTest1Collection();
+            var unitTest1Collection = this.GetUnitTestCollection(collectionName);
 
             var testNodes = unitTest1Collection.SelectNodes($"test[@name=\"{queryTestName}\"]");
             return testNodes.Item(0);
         }
 
+        private XmlNodeList GetTestXmlNodePartial(
+            string collectionName,
+            string testName)
+        {
+            var unitTest1Collection = this.GetUnitTestCollection(collectionName);
+
+            var testNodes = unitTest1Collection.SelectNodes($"test[contains(@name, \"{testName}\")]");
+            return testNodes;
+        }
+
+        private XmlNode GetUnitTestCollection(string name)
+        {
+            var testNodes = this.testResultsXmlDocument.SelectNodes(
+                $"//assemblies/assembly/collection[contains(@name, \"{name}\")]");
+
+            Assert.Equal(1, testNodes.Count);
+            return testNodes.Item(0);
+        }
+
         private XmlNode GetUnitTest1Collection()
         {
-            XmlNodeList collectionElementNodeList =
-                this.testResultsXmlDocument.SelectNodes(TestResultsXmlTests.CollectionElement);
-
-            Assert.True(collectionElementNodeList.Count == 2);
-
-            XmlNode unitTest1Collection = null;
-            var firstCollectionName = collectionElementNodeList[0].Attributes["name"];
-            unitTest1Collection = "Test collection for Xunit.Xml.TestLogger.NetCore.Tests.UnitTest1".Equals(firstCollectionName.Value)
-                ? collectionElementNodeList[0] : collectionElementNodeList[1];
-
-            return unitTest1Collection;
+            return this.GetUnitTestCollection("UnitTest1");
         }
     }
 }

--- a/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
+++ b/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
@@ -36,4 +36,13 @@ namespace Xunit.Xml.TestLogger.NetCore.Tests
             Assert.False(true);
         }
     }
+
+    public class UnitTest3
+    {
+        [Theory]
+        [InlineData("Head\x80r")]    // See issue #25
+        public void TestInvalidName(string input)
+        {
+        }
+    }
 }


### PR DESCRIPTION
* Use the latest Spekt.TestLogger drop with common xml utilities
* Document logger options supported with core logger