### PR TITLE
fix: testcase name parser regex to include zero.

### DIFF
--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -4,7 +4,7 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NETTestSdkVersion>15.7.2</NETTestSdkVersion>
     <MoqVersion>4.9.0</MoqVersion>
-    <TestLoggerVersion>3.0.78</TestLoggerVersion>
+    <TestLoggerVersion>3.0.86</TestLoggerVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.5.0</NETTestSdkMinimumVersion>


### PR DESCRIPTION
https://github.com/spekt/testlogger/issues/35