### PR TITLE
Illegal xml char

### DIFF
--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -4,7 +4,7 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NETTestSdkVersion>15.7.2</NETTestSdkVersion>
     <MoqVersion>4.9.0</MoqVersion>
-    <TestLoggerVersion>3.0.86</TestLoggerVersion>
+    <TestLoggerVersion>3.0.122</TestLoggerVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.5.0</NETTestSdkMinimumVersion>

--- a/src/Xunit.Xml.TestLogger.TestAdapter/Xunit.Xml.TestLogger.TestAdapter.csproj
+++ b/src/Xunit.Xml.TestLogger.TestAdapter/Xunit.Xml.TestLogger.TestAdapter.csproj
@@ -26,10 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
+    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
-    <ItemGroup>
-    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
-  </ItemGroup>  
 </Project>

--- a/src/Xunit.Xml.TestLogger.TestAdapter/Xunit.Xml.TestLogger.TestAdapter.csproj
+++ b/src/Xunit.Xml.TestLogger.TestAdapter/Xunit.Xml.TestLogger.TestAdapter.csproj
@@ -26,7 +26,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
-    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
+
+    <ItemGroup>
+    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
+  </ItemGroup>  
 </Project>

--- a/src/Xunit.Xml.TestLogger/Xunit.Xml.TestLogger.csproj
+++ b/src/Xunit.Xml.TestLogger/Xunit.Xml.TestLogger.csproj
@@ -18,10 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
+    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
-    <ItemGroup>
-    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Xunit.Xml.TestLogger/Xunit.Xml.TestLogger.csproj
+++ b/src/Xunit.Xml.TestLogger/Xunit.Xml.TestLogger.csproj
@@ -18,8 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
-    <PackageReference Include="Spekt.TestLogger" Version="$(TestLoggerVersion)" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
+    <ItemGroup>
+    <ProjectReference Include="..\..\..\testlogger\src\TestLogger\TestLogger.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
         {
             var element = new XElement(
                 "test",
-                new XAttribute("name", result.TestCaseDisplayName),
+                new XAttribute("name", result.Method),
                 new XAttribute("type", result.FullTypeName),
                 new XAttribute("method", result.Method),
                 new XAttribute("time", result.Duration.TotalSeconds.ToString("F7", CultureInfo.InvariantCulture)),

--- a/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
@@ -291,9 +291,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
                     new XElement("stack-trace", result.ErrorStackTrace)));
             }
 
-            if (result.TestCase.Traits != null)
+            if (result.Traits != null)
             {
-                var traits = from trait in result.TestCase.Traits
+                var traits = from trait in result.Traits
                              select new XElement("trait", new XAttribute("name", trait.Name), new XAttribute("value", trait.Value));
                 element.Add(new XElement("traits", traits));
             }

--- a/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
         {
             var element = new XElement(
                 "test",
-                new XAttribute("name", result.TestCase.DisplayName),
+                new XAttribute("name", result.TestCaseDisplayName),
                 new XAttribute("type", result.FullTypeName),
                 new XAttribute("method", result.Method),
                 new XAttribute("time", result.Duration.TotalSeconds.ToString("F7", CultureInfo.InvariantCulture)),

--- a/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
@@ -276,11 +276,11 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
                 element.Add(new XElement("output", stdOut.ToString()));
             }
 
-            var fileName = result.TestCase.CodeFilePath;
+            var fileName = result.CodeFilePath;
             if (!string.IsNullOrWhiteSpace(fileName))
             {
                 element.Add(new XElement("source-file", fileName));
-                element.Add(new XElement("source-line", result.TestCase.LineNumber));
+                element.Add(new XElement("source-line", result.LineNumber));
             }
 
             if (result.Outcome == TestOutcome.Failed)

--- a/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
         {
             var element = new XElement(
                 "test",
-                new XAttribute("name", result.Method),
+                new XAttribute("name", result.DisplayName),
                 new XAttribute("type", result.FullTypeName),
                 new XAttribute("method", result.Method),
                 new XAttribute("time", result.Duration.TotalSeconds.ToString("F7", CultureInfo.InvariantCulture)),

--- a/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
@@ -39,6 +39,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
             { "Test Method Cleanup Failure", "test-method-cleanup" }
         };
 
+        public IInputSanitizer InputSanitizer { get; } = new InputSanitizerXml();
+
         public string Serialize(
             LoggerConfiguration loggerConfiguration,
             TestRunConfiguration runConfiguration,

--- a/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
+++ b/src/Xunit.Xml.TestLogger/XunitXmlSerializer.cs
@@ -169,8 +169,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
         private static XElement CreateFailureElement(string exceptionType, string message, string stackTrace)
         {
             XElement failureElement = new XElement("failure", new XAttribute("exception-type", exceptionType));
-            failureElement.Add(new XElement("message", message.ReplaceInvalidXmlChar()));
-            failureElement.Add(new XElement("stack-trace", stackTrace.ReplaceInvalidXmlChar()));
+            failureElement.Add(new XElement("message", message));
+            failureElement.Add(new XElement("stack-trace", stackTrace));
 
             return failureElement;
         }
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
         {
             var element = new XElement(
                 "test",
-                new XAttribute("name", result.TestCase.DisplayName.ReplaceInvalidXmlChar()),
+                new XAttribute("name", result.TestCase.DisplayName),
                 new XAttribute("type", result.FullTypeName),
                 new XAttribute("method", result.Method),
                 new XAttribute("time", result.Duration.TotalSeconds.ToString("F7", CultureInfo.InvariantCulture)),
@@ -267,13 +267,13 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
                 else if (m.Category == "skipReason")
                 {
                     // Using the self-defined category skipReason for now
-                    element.Add(new XElement("reason", new XCData(m.Text.ReplaceInvalidXmlChar())));
+                    element.Add(new XElement("reason", new XCData(m.Text)));
                 }
             }
 
             if (!string.IsNullOrWhiteSpace(stdOut.ToString()))
             {
-                element.Add(new XElement("output", stdOut.ToString().ReplaceInvalidXmlChar()));
+                element.Add(new XElement("output", stdOut.ToString()));
             }
 
             var fileName = result.TestCase.CodeFilePath;
@@ -287,8 +287,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger
             {
                 element.Add(new XElement(
                     "failure",
-                    new XElement("message", result.ErrorMessage.ReplaceInvalidXmlChar()),
-                    new XElement("stack-trace", result.ErrorStackTrace.ReplaceInvalidXmlChar())));
+                    new XElement("message", result.ErrorMessage),
+                    new XElement("stack-trace", result.ErrorStackTrace)));
             }
 
             if (result.TestCase.Traits != null)


### PR DESCRIPTION
Continuation of https://github.com/spekt/xunit.testlogger/pull/44

* Use xml sanitizer from testlogger core.
* Use DisplayName for reporting test case name.