### PR TITLE
fix: report nested test classes correctly. See #48.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased (v3.1.x)
 
+- Fix for reporting nested test classes. See #48 and
+  https://github.com/spekt/testlogger/pull/41/. Thanks @pageyboy.
+- Update core testlogger to 3.1.138.
+- Infra: fix build when repo is cloned in path with whitespace.
+
 ## v3.1.11 - 2023/07/06
 
 - Update core testlogger to 3.1.130.
@@ -15,25 +20,24 @@
 - Fix: Explicit tests should be marked as Skipped. See
   https://github.com/spekt/nunit.testlogger/issues/86
 - Replace Test Case name parser **Possible Breaking Change**
-    - For most or maybe all users the new parser should fix the issues shown below, without introducing new issues. In case you do encounter any new parsing failures a feature flag `Parser=Legacy` has been added to use the prior parser. See [logger config wiki](https://github.com/spekt/testlogger/wiki/Logger-Configuration) for details. 
-    - Fix: Test case parse error if name contains special characters. See
-  https://github.com/spekt/nunit.testlogger/issues/90
-    - Fix: Covers several parsing issues. Thanks @becha2 for all the detailed examples.
-       https://github.com/spekt/testlogger/issues/28
-    - Fix: Log member data. Thanks @BottlecapDave for the issue report and @hach-que for the draft fix. 
-      https://github.com/spekt/junit.testlogger/issues/50
-    - Fix: Issue parsing chars. Thanks @binarycow for the issue report.
-       https://github.com/spekt/nunit.testlogger/issues/90
-    - Reduce log verbosity: The parser, if it encounters problems, will only output one warning per run to the console instead of one per problem
-    - Fix: Issue parsing numbers. See https://github.com/spekt/testlogger/issues/35
-
+  - For most or maybe all users the new parser should fix the issues shown below, without introducing new issues. In case you do encounter any new parsing failures a feature flag `Parser=Legacy` has been added to use the prior parser. See [logger config wiki](https://github.com/spekt/testlogger/wiki/Logger-Configuration) for details.
+  - Fix: Test case parse error if name contains special characters. See
+    https://github.com/spekt/nunit.testlogger/issues/90
+  - Fix: Covers several parsing issues. Thanks @becha2 for all the detailed examples.
+    https://github.com/spekt/testlogger/issues/28
+  - Fix: Log member data. Thanks @BottlecapDave for the issue report and @hach-que for the draft fix.
+    https://github.com/spekt/junit.testlogger/issues/50
+  - Fix: Issue parsing chars. Thanks @binarycow for the issue report.
+    https://github.com/spekt/nunit.testlogger/issues/90
+  - Reduce log verbosity: The parser, if it encounters problems, will only output one warning per run to the console instead of one per problem
+  - Fix: Issue parsing numbers. See https://github.com/spekt/testlogger/issues/35
 
 ## v3.0.70 - 2021/11/01
 
 - Upgrade testlogger to 3.0.47
 - Fix: generate test results when used along with JUnit.TestLogger. See
-https://github.com/spekt/xunit.testlogger/issues/36 and
-https://github.com/spekt/xunit.testlogger/issues/37
+  https://github.com/spekt/xunit.testlogger/issues/36 and
+  https://github.com/spekt/xunit.testlogger/issues/37
 
 ## v3.0.66 - 2021/03/10
 

--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -4,7 +4,7 @@
     <MSTestVersion>3.0.4</MSTestVersion>
     <NETTestSdkVersion>17.3.2</NETTestSdkVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <TestLoggerVersion>3.1.130</TestLoggerVersion>
+    <TestLoggerVersion>3.1.138</TestLoggerVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.5.0</NETTestSdkMinimumVersion>

--- a/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
+++ b/test/Xunit.Xml.TestLogger.AcceptanceTests/TestResultsXmlTests.cs
@@ -19,6 +19,9 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         private const string AssembliesElement = @"/assemblies";
         private const string AssemblyElement = @"/assemblies/assembly";
         private const string CollectionElement = @"/assemblies/assembly/collection";
+        private const string TotalTestsCount = "9";
+        private const string TotalPassingTestsCount = "6";
+        private const int TotalTestClassesCount = 5;
 
         private string testResultsFilePath;
         private XmlDocument testResultsXmlDocument;
@@ -134,7 +137,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         {
             XmlNode assemblyNode = this.testResultsXmlDocument.SelectSingleNode(TestResultsXmlTests.AssemblyElement);
 
-            Assert.Equal("6", assemblyNode.Attributes["total"].Value);
+            Assert.Equal(TotalTestsCount, assemblyNode.Attributes["total"].Value);
         }
 
         [Fact]
@@ -142,7 +145,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         {
             XmlNode assemblyNode = this.testResultsXmlDocument.SelectSingleNode(TestResultsXmlTests.AssemblyElement);
 
-            Assert.Equal("3", assemblyNode.Attributes["passed"].Value);
+            Assert.Equal(TotalPassingTestsCount, assemblyNode.Attributes["passed"].Value);
         }
 
         [Fact]
@@ -193,7 +196,7 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
         {
             XmlNodeList collectionElementNodeList = this.testResultsXmlDocument.SelectNodes(TestResultsXmlTests.CollectionElement);
 
-            Assert.Equal(3, collectionElementNodeList.Count);
+            Assert.Equal(TotalTestClassesCount, collectionElementNodeList.Count);
         }
 
         [Fact]
@@ -349,6 +352,17 @@ namespace Xunit.Xml.TestLogger.AcceptanceTests
 
             string expectedReason = "Skipped";
             Assert.Equal(expectedReason, reasonData.Value);
+        }
+
+        [Fact]
+        public void NestedTestClassesShouldBePresent()
+        {
+            XmlNode nestedTestNode = this.GetATestXmlNode(
+                    "ChildUnitNestedTest3332",
+                    "Xunit.Xml.TestLogger.NetCore.Tests.ParentUnitNestedTest3332+ChildUnitNestedTest3332.PassTest33321");
+            var result = nestedTestNode.Attributes["result"];
+
+            Assert.Equal("Pass", result.Value);
         }
 
         private XmlNode GetATestXmlNode(

--- a/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/NestedTest1.cs
+++ b/test/assets/Xunit.Xml.TestLogger.NetCore.Tests/NestedTest1.cs
@@ -1,0 +1,25 @@
+using System;
+using Xunit;
+
+namespace Xunit.Xml.TestLogger.NetCore.Tests
+{
+    public class ParentUnitNestedTest3331
+    {
+        [Fact]
+        public void PassTest33311()
+        {
+        }
+    }
+
+    public class ParentUnitNestedTest3332
+    {
+        public class ChildUnitNestedTest3332 : ParentUnitNestedTest3331
+        {
+            [Fact]
+            public void PassTest33321()
+            {
+                Assert.Equal(2, 2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Uptake fix from https://github.com/spekt/testlogger/pull/41. Thanks @pageyboy.